### PR TITLE
Added MailSlurper to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [MailHog](https://github.com/mailhog/MailHog) - Email and SMTP testing with web and API interface
 * [SendGrid](https://github.com/sendgrid/sendgrid-go) - SendGrid's Go library for sending email
 * [smtp](https://github.com/mailhog/smtp) - SMTP server protocol state machine
-
+* [MailSlurper](http://mailslurper.com) - A handy SMTP mail server useful for local and team application development. Slurp mail into oblivion!
 
 
 ## Embeddable Scripting Languages


### PR DESCRIPTION
I would like to add MailSlurper to the list please. 
- http://mailslurper.com
- https://github.com/mailslurper
- https://goreportcard.com/report/github.com/mailslurper/mailslurper
- https://goreportcard.com/report/github.com/mailslurper/libmailslurper
